### PR TITLE
Set opacity to all actors that support it

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -18,10 +18,14 @@ function set_opacity(actor, value)
 {
 	for (const child of actor.get_children())
 	{
-		child.set_opacity(value);
+		if (child.set_opacity) {
+			child.set_opacity(value);
+		}
 	}
 
-	actor.set_opacity(value);
+	if (actor.set_opacity) {
+		actor.set_opacity(value);
+	}
 }
 
 function focus(win)

--- a/extension.js
+++ b/extension.js
@@ -14,10 +14,20 @@ let create_signal = undefined;
 function init() {
 }
 
+function set_opacity(actor, value)
+{
+	for (const child of actor.get_children())
+	{
+		child.set_opacity(value);
+	}
+
+	actor.set_opacity(value);
+}
+
 function focus(win)
 {
 	for (const actor of global.get_window_actors()) {
-		actor.get_children()[0].set_opacity((actor.get_meta_window() === win) ? FOCUS_OPACITY : INACTIVE_OPACITY);
+		set_opacity(actor, (actor.get_meta_window() === win) ? FOCUS_OPACITY : INACTIVE_OPACITY);
 	}
 }
 
@@ -35,7 +45,7 @@ function enable() {
 		}
 
 		if (win !== global.display.focus_window) {
-			actor.get_children()[0].set_opacity(INACTIVE_OPACITY);
+			set_opacity(actor, INACTIVE_OPACITY);
 		}
 	}
 }
@@ -55,6 +65,6 @@ function disable() {
 			delete win._gnome_focus_signal;
 		}
 
-		actor.get_children()[0].set_opacity(FOCUS_OPACITY);
+		set_opacity(actor, FOCUS_OPACITY);
 	}
 }


### PR DESCRIPTION
Apps like Firefox appear to have both a Wayland and X MetaSurface actor. So it doesn't appear to have the opacity be set. Having this aggressive way of setting opacity makes it work with Firefox while continuing to work with other apps as well.