### PR TITLE
Add gnome40 as supported version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
 	"uuid": "focus@scaryrawr.github.io",
 	"name": "Focus",
-	"shell-version": ["3.38", "40.beta"],
+	"shell-version": ["3.38", "40.beta", "40"],
 	"url": "https://github.com/scaryrawr/gnome-focus"
 }


### PR DESCRIPTION
Build and tested on my GNOME40 desktop, still seems to work like a charm. 

Thanks for this extension! 