### PR TITLE
Add 47 to supported GS versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
 	"uuid": "focus@scaryrawr.github.io",
 	"name": "Focus",
-	"shell-version": ["45", "46"],
+	"shell-version": ["45", "46", "47"],
 	"url": "https://github.com/scaryrawr/gnome-focus",
 	"settings-schema": "org.gnome.shell.extensions.focus"
 }


### PR DESCRIPTION
I've tested this on GNOME Shell version 47 and it seems to be working fine without modifications. None of the items on the GS 47 extension upgrade guide [1] seem to apply here. This PR adds 47 to the list of supported shell versions.

[1] https://gjs.guide/extensions/upgrading/gnome-shell-47.html