### PR TITLE
Feat: Add desaturation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Transparent inactive windows",
   "type": "module",
   "private": true,

--- a/schemas/org.gnome.shell.extensions.focus.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.focus.gschema.xml
@@ -13,10 +13,6 @@
 			<default>100</default>
 			<summary>Opacity of focused window 0-100</summary>
 		</key>
-		<key name="blur-sigma" type="u">
-			<default>5</default>
-			<summary>Blur sigma to be applied</summary>
-		</key>
 		<key name="is-background-blur" type="b">
 			<default>false</default>
 			<summary>Have blurred backgrounds</summary>

--- a/schemas/org.gnome.shell.extensions.focus.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.focus.gschema.xml
@@ -21,5 +21,13 @@
 			<default>false</default>
 			<summary>Have blurred backgrounds</summary>
 		</key>
+		<key name="desaturate-percentage" type="u">
+			<default>50</default>
+			<summary>Desaturation percentage applied to inactive windows 0-100</summary>
+		</key>
+		<key name="is-desaturate-enabled" type="b">
+			<default>false</default>
+			<summary>Enable desaturation effect for inactive windows</summary>
+		</key>
 	</schema>
 </schemalist>

--- a/src/GnomeFocusManager.ts
+++ b/src/GnomeFocusManager.ts
@@ -228,8 +228,5 @@ export class GnomeFocusManager {
       window_actor.remove_effect_by_name(BLUR_EFFECT_NAME);
       window_actor.remove_effect_by_name(DESATURATE_EFFECT_NAME);
     }
-
-    delete this.blur_effect;
-    delete this.desaturate_effect;
   }
 }

--- a/src/GnomeFocusManager.ts
+++ b/src/GnomeFocusManager.ts
@@ -155,12 +155,8 @@ export class GnomeFocusManager {
       : this.settings.focus_opacity;
 
     GnomeFocusManager.set_opacity(this.active_window_actor, opacity);
-    this.set_blur(this.active_window_actor, this.settings.is_background_blur);
-    this.set_desaturate(
-      this.active_window_actor,
-      this.settings.is_desaturate_enabled,
-      this.settings.desaturate_percentage
-    );
+    this.set_blur(this.active_window_actor, false);
+    this.set_desaturate(this.active_window_actor, false, this.settings.desaturate_percentage);
 
     this.active_destroy_signal = this.active_window_actor.connect('destroy', actor => {
       if (this.active_window_actor === actor) {

--- a/src/GnomeFocusManager.ts
+++ b/src/GnomeFocusManager.ts
@@ -32,7 +32,6 @@ export class GnomeFocusManager {
     settings.on('focus-opacity', this.update_focused_window_opacity);
     settings.on('special-opacity', this.update_special_focused_window_opacity);
     settings.on('inactive-opacity', this.update_inactive_windows_opacity);
-    settings.on('blur-sigma', this.update_blur_sigma);
     settings.on('is-background-blur', this.update_is_background_blur);
     settings.on('is-desaturate-enabled', this.update_is_desaturate_enabled);
     settings.on('desaturate-percentage', this.update_desaturate_percentage);
@@ -91,8 +90,7 @@ export class GnomeFocusManager {
     window_actor.set_opacity(true_opacity);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  set_blur(window_actor: Meta.WindowActor, blur: boolean, sigma: number): void {
+  set_blur(window_actor: Meta.WindowActor, blur: boolean): void {
     const meta_window = window_actor.get_meta_window();
     if (window_actor.is_destroyed() || !meta_window || !is_valid_window_type(meta_window)) {
       return;
@@ -129,7 +127,8 @@ export class GnomeFocusManager {
     }
 
     GnomeFocusManager.set_opacity(window_actor, this.settings.inactive_opacity);
-    this.set_blur(window_actor, this.settings.is_background_blur, this.settings.blur_sigma);
+    this.set_blur(window_actor, this.settings.is_background_blur);
+    this.set_desaturate(window_actor, this.settings.is_desaturate_enabled, this.settings.desaturate_percentage);
   };
 
   set_active_window_actor = (window_actor: Meta.WindowActor): void => {
@@ -156,7 +155,12 @@ export class GnomeFocusManager {
       : this.settings.focus_opacity;
 
     GnomeFocusManager.set_opacity(this.active_window_actor, opacity);
-    this.set_blur(this.active_window_actor, this.settings.is_background_blur, this.settings.blur_sigma);
+    this.set_blur(this.active_window_actor, this.settings.is_background_blur);
+    this.set_desaturate(
+      this.active_window_actor,
+      this.settings.is_desaturate_enabled,
+      this.settings.desaturate_percentage
+    );
 
     this.active_destroy_signal = this.active_window_actor.connect('destroy', actor => {
       if (this.active_window_actor === actor) {
@@ -193,23 +197,12 @@ export class GnomeFocusManager {
   };
 
   update_is_background_blur = (blur: boolean): void => {
-    const sigma = this.settings.blur_sigma;
     for (const window_actor of global.get_window_actors()) {
       if (this.is_ignored(window_actor)) {
         continue;
       }
 
-      this.set_blur(window_actor, blur, sigma);
-    }
-  };
-
-  update_blur_sigma = (sigma: number): void => {
-    for (const window_actor of global.get_window_actors()) {
-      if (this.is_ignored(window_actor)) {
-        continue;
-      }
-
-      this.set_blur(window_actor, this.settings.is_background_blur, sigma);
+      this.set_blur(window_actor, blur);
     }
   };
 

--- a/src/GnomeFocusManager.ts
+++ b/src/GnomeFocusManager.ts
@@ -21,9 +21,6 @@ export function is_valid_window_type(window: Meta.Window): boolean {
 export class GnomeFocusManager {
   active_window_actor: Meta.WindowActor | undefined;
   active_destroy_signal: number | undefined;
-  blur_effect: Clutter.BlurEffect | undefined;
-  desaturate_effect: Clutter.DesaturateEffect | undefined;
-
   constructor(
     readonly settings: FocusSettings,
     readonly special_focus: string[] | undefined,
@@ -96,17 +93,13 @@ export class GnomeFocusManager {
       return;
     }
 
-    this.blur_effect ??= Clutter.BlurEffect.new();
-    this.blur_effect.set_enabled(true);
-
-    if (blur) {
-      const window_blur_effect = window_actor.get_effect(BLUR_EFFECT_NAME);
-      if (!window_blur_effect) {
-        window_actor.add_effect_with_name(BLUR_EFFECT_NAME, this.blur_effect);
-      }
-    } else {
-      window_actor.remove_effect_by_name(BLUR_EFFECT_NAME);
+    let blur_effect = window_actor.get_effect(BLUR_EFFECT_NAME);
+    if (!blur_effect) {
+      blur_effect = Clutter.BlurEffect.new();
+      window_actor.add_effect_with_name(BLUR_EFFECT_NAME, blur_effect);
     }
+
+    blur_effect.set_enabled(blur);
   }
 
   set_desaturate(window_actor: Meta.WindowActor, desaturate: boolean, percentage: number): void {
@@ -115,18 +108,14 @@ export class GnomeFocusManager {
       return;
     }
 
-    this.desaturate_effect ??= Clutter.DesaturateEffect.new(percentage / 100);
-    this.desaturate_effect.set_enabled(true);
-    this.desaturate_effect.set_factor(percentage / 100);
-
-    if (desaturate) {
-      const window_desaturate_effect = window_actor.get_effect(DESATURATE_EFFECT_NAME);
-      if (!window_desaturate_effect) {
-        window_actor.add_effect_with_name(DESATURATE_EFFECT_NAME, this.desaturate_effect);
-      }
-    } else {
-      window_actor.remove_effect_by_name(DESATURATE_EFFECT_NAME);
+    let desaturate_effect = window_actor.get_effect(DESATURATE_EFFECT_NAME) as Clutter.DesaturateEffect | null;
+    if (!desaturate_effect) {
+      desaturate_effect = Clutter.DesaturateEffect.new(percentage / 100);
+      window_actor.add_effect_with_name(DESATURATE_EFFECT_NAME, desaturate_effect);
     }
+
+    desaturate_effect.set_factor(percentage / 100);
+    desaturate_effect.set_enabled(desaturate);
   }
 
   update_inactive_window_actor = (window_actor: Meta.WindowActor): void => {

--- a/src/GnomeFocusManager.ts
+++ b/src/GnomeFocusManager.ts
@@ -97,11 +97,15 @@ export class GnomeFocusManager {
     }
 
     this.blur_effect ??= Clutter.BlurEffect.new();
-    this.blur_effect.set_enabled(blur);
+    this.blur_effect.set_enabled(true);
 
-    const window_blur_effect = window_actor.get_effect(BLUR_EFFECT_NAME);
-    if (!window_blur_effect) {
-      window_actor.add_effect_with_name(BLUR_EFFECT_NAME, this.blur_effect);
+    if (blur) {
+      const window_blur_effect = window_actor.get_effect(BLUR_EFFECT_NAME);
+      if (!window_blur_effect) {
+        window_actor.add_effect_with_name(BLUR_EFFECT_NAME, this.blur_effect);
+      }
+    } else {
+      window_actor.remove_effect_by_name(BLUR_EFFECT_NAME);
     }
   }
 
@@ -112,12 +116,16 @@ export class GnomeFocusManager {
     }
 
     this.desaturate_effect ??= Clutter.DesaturateEffect.new(percentage / 100);
-    this.desaturate_effect.set_enabled(desaturate);
+    this.desaturate_effect.set_enabled(true);
     this.desaturate_effect.set_factor(percentage / 100);
 
-    const window_desaturate_effect = window_actor.get_effect(DESATURATE_EFFECT_NAME);
-    if (!window_desaturate_effect) {
-      window_actor.add_effect_with_name(DESATURATE_EFFECT_NAME, this.desaturate_effect);
+    if (desaturate) {
+      const window_desaturate_effect = window_actor.get_effect(DESATURATE_EFFECT_NAME);
+      if (!window_desaturate_effect) {
+        window_actor.add_effect_with_name(DESATURATE_EFFECT_NAME, this.desaturate_effect);
+      }
+    } else {
+      window_actor.remove_effect_by_name(DESATURATE_EFFECT_NAME);
     }
   }
 

--- a/src/GnomeFocusManager.ts
+++ b/src/GnomeFocusManager.ts
@@ -202,7 +202,7 @@ export class GnomeFocusManager {
 
   update_is_background_blur = (blur: boolean): void => {
     for (const window_actor of global.get_window_actors()) {
-      if (this.is_ignored(window_actor)) {
+      if (window_actor === this.active_window_actor || this.is_ignored(window_actor)) {
         continue;
       }
 
@@ -213,7 +213,7 @@ export class GnomeFocusManager {
   update_is_desaturate_enabled = (enabled: boolean): void => {
     const percentage = this.settings.desaturate_percentage;
     for (const window_actor of global.get_window_actors()) {
-      if (this.is_ignored(window_actor)) {
+      if (window_actor === this.active_window_actor || this.is_ignored(window_actor)) {
         continue;
       }
 
@@ -224,7 +224,7 @@ export class GnomeFocusManager {
   update_desaturate_percentage = (percentage: number): void => {
     const enabled = this.settings.is_desaturate_enabled;
     for (const window_actor of global.get_window_actors()) {
-      if (this.is_ignored(window_actor)) {
+      if (window_actor === this.active_window_actor || this.is_ignored(window_actor)) {
         continue;
       }
 

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -91,33 +91,6 @@ export default class GnomeFocusPreferences extends ExtensionPreferences {
 
     widget.attach(blur_toggle, 1, 7, 1, 1);
 
-    const blur_sigma_label = new Gtk.Label({
-      label: 'Blur Sigma',
-      halign: Gtk.Align.START,
-      visible: true
-    });
-
-    const blur_sigma_entry = new Gtk.Entry({
-      inputPurpose: Gtk.InputPurpose.NUMBER,
-      visible: true
-    });
-
-    blur_sigma_entry.set_text(settings.blur_sigma.toString());
-    blur_sigma_entry.connect('changed', function () {
-      if (!blur_sigma_entry.text) {
-        return;
-      }
-
-      const value = parseInt(blur_sigma_entry.text);
-      if (!isNaN(value) && value >= 0) {
-        settings.set_blur_sigma(value);
-        Gio.Settings.sync();
-      }
-    });
-
-    widget.attach(blur_sigma_label, 0, 8, 1, 1);
-    widget.attach(blur_sigma_entry, 1, 8, 1, 1);
-
     const desaturate_label = new Gtk.Label({
       label: 'Desaturate Inactive Windows',
       halign: Gtk.Align.START,
@@ -134,8 +107,8 @@ export default class GnomeFocusPreferences extends ExtensionPreferences {
       Gio.Settings.sync();
     });
 
-    widget.attach(desaturate_label, 0, 9, 1, 1);
-    widget.attach(desaturate_toggle, 1, 9, 1, 1);
+    widget.attach(desaturate_label, 0, 8, 1, 1);
+    widget.attach(desaturate_toggle, 1, 8, 1, 1);
 
     const desaturate_percentage_label = new Gtk.Label({
       label: 'Desaturate Percentage',
@@ -154,8 +127,8 @@ export default class GnomeFocusPreferences extends ExtensionPreferences {
       }
     });
 
-    widget.attach(desaturate_percentage_label, 0, 10, 1, 1);
-    widget.attach(desaturate_percentage_scale, 1, 10, 1, 1);
+    widget.attach(desaturate_percentage_label, 0, 9, 1, 1);
+    widget.attach(desaturate_percentage_scale, 1, 9, 1, 1);
 
     return widget;
   }

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -128,7 +128,7 @@ export default class GnomeFocusPreferences extends ExtensionPreferences {
     });
 
     widget.attach(desaturate_percentage_label, 0, 9, 1, 1);
-    widget.attach(desaturate_percentage_scale, 1, 9, 1, 1);
+    widget.attach(desaturate_percentage_scale, 0, 10, 2, 1);
 
     return widget;
   }

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -118,6 +118,45 @@ export default class GnomeFocusPreferences extends ExtensionPreferences {
     widget.attach(blur_sigma_label, 0, 8, 1, 1);
     widget.attach(blur_sigma_entry, 1, 8, 1, 1);
 
+    const desaturate_label = new Gtk.Label({
+      label: 'Desaturate Inactive Windows',
+      halign: Gtk.Align.START,
+      visible: true
+    });
+
+    const desaturate_toggle = new Gtk.Switch({
+      visible: true,
+      active: settings.is_desaturate_enabled
+    });
+
+    desaturate_toggle.connect('notify::active', () => {
+      settings.set_is_desaturate_enabled(desaturate_toggle.get_active());
+      Gio.Settings.sync();
+    });
+
+    widget.attach(desaturate_label, 0, 9, 1, 1);
+    widget.attach(desaturate_toggle, 1, 9, 1, 1);
+
+    const desaturate_percentage_label = new Gtk.Label({
+      label: 'Desaturate Percentage',
+      halign: Gtk.Align.START,
+      visible: true
+    });
+
+    const desaturate_percentage_scale = Gtk.Scale.new_with_range(Gtk.Orientation.HORIZONTAL, 0, 100, 1);
+    desaturate_percentage_scale.set_visible(true);
+    desaturate_percentage_scale.set_value(settings.desaturate_percentage);
+    desaturate_percentage_scale.connect('change-value', () => {
+      const value = desaturate_percentage_scale.get_value();
+      if (value <= 100 && value >= 0) {
+        settings.set_desaturate_percentage(value);
+        Gio.Settings.sync();
+      }
+    });
+
+    widget.attach(desaturate_percentage_label, 0, 10, 1, 1);
+    widget.attach(desaturate_percentage_scale, 1, 10, 1, 1);
+
     return widget;
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,7 +4,6 @@ type SettingsChangeEvents = {
   'focus-opacity': number;
   'special-opacity': number;
   'inactive-opacity': number;
-  'blur-sigma': number;
   'is-background-blur': boolean;
   'is-desaturate-enabled': boolean;
   'desaturate-percentage': number;
@@ -27,7 +26,6 @@ export class FocusSettings {
     'focus-opacity': [],
     'inactive-opacity': [],
     'special-opacity': [],
-    'blur-sigma': [],
     'is-background-blur': [],
     'desaturate-percentage': [],
     'is-desaturate-enabled': []
@@ -61,14 +59,6 @@ export class FocusSettings {
     this.settings.set_uint('inactive-opacity', val);
   }
 
-  get blur_sigma(): number {
-    return this.settings.get_uint('blur-sigma');
-  }
-
-  set_blur_sigma(val: number): void {
-    this.settings.set_uint('blur-sigma', val);
-  }
-
   get is_background_blur(): boolean {
     return this.settings.get_boolean('is-background-blur');
   }
@@ -100,9 +90,6 @@ export class FocusSettings {
           case 'focus-opacity':
           case 'inactive-opacity':
           case 'special-opacity':
-          case 'blur-sigma':
-            this.emit(key, this.settings.get_uint(key));
-            break;
           case 'is-background-blur':
             this.emit(key, this.settings.get_boolean(key));
             break;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,8 @@ type SettingsChangeEvents = {
   'inactive-opacity': number;
   'blur-sigma': number;
   'is-background-blur': boolean;
+  'is-desaturate-enabled': boolean;
+  'desaturate-percentage': number;
 };
 
 type CallbackTypes<Type> = {
@@ -26,7 +28,9 @@ export class FocusSettings {
     'inactive-opacity': [],
     'special-opacity': [],
     'blur-sigma': [],
-    'is-background-blur': []
+    'is-background-blur': [],
+    'desaturate-percentage': [],
+    'is-desaturate-enabled': []
   };
 
   constructor(settings: Gio.Settings) {
@@ -73,6 +77,22 @@ export class FocusSettings {
     this.settings.set_boolean('is-background-blur', val);
   }
 
+  get desaturate_percentage(): number {
+    return this.settings.get_uint('desaturate-percentage');
+  }
+
+  set_desaturate_percentage(val: number): void {
+    this.settings.set_uint('desaturate-percentage', val);
+  }
+
+  get is_desaturate_enabled(): boolean {
+    return this.settings.get_boolean('is-desaturate-enabled');
+  }
+
+  set_is_desaturate_enabled(val: boolean): void {
+    this.settings.set_boolean('is-desaturate-enabled', val);
+  }
+
   on<E extends keyof SettingsChangeEvents>(event: E, callback: CallbackTypes<SettingsChangeEvents>[E]): void {
     if (this.connection === undefined) {
       this.connection = this.settings.connect('changed', (_, key: keyof SettingsChangeEvents) => {
@@ -84,6 +104,12 @@ export class FocusSettings {
             this.emit(key, this.settings.get_uint(key));
             break;
           case 'is-background-blur':
+            this.emit(key, this.settings.get_boolean(key));
+            break;
+          case 'desaturate-percentage':
+            this.emit(key, this.settings.get_uint(key));
+            break;
+          case 'is-desaturate-enabled':
             this.emit(key, this.settings.get_boolean(key));
             break;
         }


### PR DESCRIPTION
Based on #48 .

Adds settings for [Clutter's DesaturateEffect](https://gnome.pages.gitlab.gnome.org/mutter/clutter/class.DesaturateEffect.html).

Also switches from Shell.BlurEffect to Clutter.BlurEffect. It's less customizable, but has less noise when using it.

![Image](https://github.com/user-attachments/assets/3dc58c36-dd2e-4bc0-b880-65c8560b91f0)