### PR TITLE
Fix settings emitter

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
-	"uuid": "focus@scaryrawr.github.io",
-	"name": "Focus",
-	"shell-version": ["45", "46", "47"],
-	"url": "https://github.com/scaryrawr/gnome-focus",
-	"settings-schema": "org.gnome.shell.extensions.focus"
+  "uuid": "focus@scaryrawr.github.io",
+  "name": "Focus",
+  "shell-version": ["45", "46", "47", "48"],
+  "url": "https://github.com/scaryrawr/gnome-focus",
+  "settings-schema": "org.gnome.shell.extensions.focus"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Transparent inactive windows",
   "type": "module",
   "private": true,

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -1,5 +1,4 @@
 import Gtk from 'gi://Gtk';
-import Gio from 'gi://Gio';
 
 import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
@@ -26,48 +25,79 @@ export default class GnomeFocusPreferences extends ExtensionPreferences {
 
     widget.attach(title, 0, 0, 1, 1);
 
-    const create_scale = (label: string, get_current_value: () => number, set_value: (value: number) => void) => {
+    const create_spin_button = ({
+      label,
+      get_current_value,
+      set_value,
+      min,
+      max,
+      step
+    }: {
+      label: string;
+      get_current_value: () => number;
+      set_value: (value: number) => void;
+      min: number;
+      max: number;
+      step: number;
+    }) => {
       const item_label = new Gtk.Label({
-        label,
+        label: `${label}: [${Math.floor(get_current_value())}]`,
         halign: Gtk.Align.START,
         visible: true
       });
 
-      const item_scale = Gtk.Scale.new_with_range(Gtk.Orientation.HORIZONTAL, 50, 100, 5);
-      item_scale.set_visible(true);
-      item_scale.set_value(get_current_value());
-      item_scale.connect('change-value', () => {
-        const value = item_scale.get_value();
-        if (value <= 100 && value >= 50) {
-          set_value(value);
-          Gio.Settings.sync();
-        }
+      const spin_button = Gtk.SpinButton.new_with_range(min, max, step);
+      spin_button.set_visible(true);
+      spin_button.set_value(get_current_value());
+
+      spin_button.connect('value-changed', (emitter: Gtk.SpinButton) => {
+        const value = emitter.get_value();
+        item_label.set_label(`${label}: [${Math.floor(value)}]`);
+        set_value(value);
       });
 
-      return [item_label, item_scale];
+      return [item_label, spin_button];
     };
 
-    const [focus_opacity_label, focus_opacity_scale] = create_scale(
-      'Focus Opacity',
-      () => settings.focus_opacity,
-      value => settings.set_focus_opacity(value)
-    );
+    const [focus_opacity_label, focus_opacity_scale] = create_spin_button({
+      label: 'Focus Opacity',
+      get_current_value: () => settings.focus_opacity,
+      set_value: value => {
+        settings.set_focus_opacity(value);
+      },
+      min: 50,
+      max: 100,
+      step: 5
+    });
+
     widget.attach(focus_opacity_label, 0, 1, 1, 1);
     widget.attach(focus_opacity_scale, 0, 2, 2, 1);
 
-    const [inactive_opacity_label, inactive_opacity_scale] = create_scale(
-      'Inactive Opacity',
-      () => settings.inactive_opacity,
-      value => settings.set_inactive_opacity(value)
-    );
+    const [inactive_opacity_label, inactive_opacity_scale] = create_spin_button({
+      label: 'Inactive Opacity',
+      get_current_value: () => settings.inactive_opacity,
+      set_value: value => {
+        settings.set_inactive_opacity(value);
+      },
+      min: 50,
+      max: 100,
+      step: 5
+    });
+
     widget.attach(inactive_opacity_label, 0, 3, 1, 1);
     widget.attach(inactive_opacity_scale, 0, 4, 2, 1);
 
-    const [special_focus_opacity_label, special_focus_opacity_scale] = create_scale(
-      'Special Focus Opacity',
-      () => settings.special_focus_opacity,
-      value => settings.set_special_focus_opacity(value)
-    );
+    const [special_focus_opacity_label, special_focus_opacity_scale] = create_spin_button({
+      label: 'Special Focus Opacity',
+      get_current_value: () => settings.special_focus_opacity,
+      set_value: value => {
+        settings.set_special_focus_opacity(value);
+      },
+      min: 50,
+      max: 100,
+      step: 5
+    });
+
     widget.attach(special_focus_opacity_label, 0, 5, 1, 1);
     widget.attach(special_focus_opacity_scale, 0, 6, 2, 1);
 
@@ -84,7 +114,6 @@ export default class GnomeFocusPreferences extends ExtensionPreferences {
 
     blur_toggle.connect('notify::active', () => {
       settings.set_is_background_blur(blur_toggle.get_active());
-      Gio.Settings.sync();
     });
 
     widget.attach(blur_label, 0, 7, 1, 1);
@@ -104,27 +133,20 @@ export default class GnomeFocusPreferences extends ExtensionPreferences {
 
     desaturate_toggle.connect('notify::active', () => {
       settings.set_is_desaturate_enabled(desaturate_toggle.get_active());
-      Gio.Settings.sync();
     });
 
     widget.attach(desaturate_label, 0, 8, 1, 1);
     widget.attach(desaturate_toggle, 1, 8, 1, 1);
 
-    const desaturate_percentage_label = new Gtk.Label({
+    const [desaturate_percentage_label, desaturate_percentage_scale] = create_spin_button({
       label: 'Desaturate Percentage',
-      halign: Gtk.Align.START,
-      visible: true
-    });
-
-    const desaturate_percentage_scale = Gtk.Scale.new_with_range(Gtk.Orientation.HORIZONTAL, 0, 100, 1);
-    desaturate_percentage_scale.set_visible(true);
-    desaturate_percentage_scale.set_value(settings.desaturate_percentage);
-    desaturate_percentage_scale.connect('change-value', () => {
-      const value = desaturate_percentage_scale.get_value();
-      if (value <= 100 && value >= 0) {
+      get_current_value: () => settings.desaturate_percentage,
+      set_value: value => {
         settings.set_desaturate_percentage(value);
-        Gio.Settings.sync();
-      }
+      },
+      min: 0,
+      max: 100,
+      step: 10
     });
 
     widget.attach(desaturate_percentage_label, 0, 9, 1, 1);

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -102,7 +102,7 @@ export default class GnomeFocusPreferences extends ExtensionPreferences {
     widget.attach(special_focus_opacity_scale, 0, 6, 2, 1);
 
     const blur_label = new Gtk.Label({
-      label: 'Blur Background [Experimental]',
+      label: 'Blur',
       halign: Gtk.Align.START,
       visible: true
     });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -90,12 +90,10 @@ export class FocusSettings {
           case 'focus-opacity':
           case 'inactive-opacity':
           case 'special-opacity':
-          case 'is-background-blur':
-            this.emit(key, this.settings.get_boolean(key));
-            break;
           case 'desaturate-percentage':
             this.emit(key, this.settings.get_uint(key));
             break;
+          case 'is-background-blur':
           case 'is-desaturate-enabled':
             this.emit(key, this.settings.get_boolean(key));
             break;


### PR DESCRIPTION
We were emitting booleans to event listeners causing windows to disappear while adjusting opacity.

This fixes it by emitting uint instead.

We also update to use a spin button vs slider for quality of live improvements for the settings pane