### PR TITLE
Add GNOME 50 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "focus@scaryrawr.github.io",
   "name": "Focus",
-  "shell-version": ["45", "46", "47", "48", "49"],
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
   "url": "https://github.com/scaryrawr/gnome-focus",
   "settings-schema": "org.gnome.shell.extensions.focus"
 }

--- a/src/GnomeFocusManager.ts
+++ b/src/GnomeFocusManager.ts
@@ -45,6 +45,23 @@ export class GnomeFocusManager {
     return targets.length > 0 ? targets : [window_actor];
   }
 
+  clear_active_window = (set_inactive = true): void => {
+    if (!this.active_window_actor) {
+      return;
+    }
+
+    if (set_inactive) {
+      this.update_inactive_window_actor(this.active_window_actor);
+    }
+
+    if (this.active_destroy_signal != null) {
+      this.active_window_actor.disconnect(this.active_destroy_signal);
+      delete this.active_destroy_signal;
+    }
+
+    delete this.active_window_actor;
+  };
+
   is_special = (window_actor: Meta.WindowActor): boolean => {
     if (!this.special_focus || window_actor.is_destroyed()) {
       return false;
@@ -146,13 +163,7 @@ export class GnomeFocusManager {
       return;
     }
 
-    if (this.active_window_actor) {
-      this.update_inactive_window_actor(this.active_window_actor);
-      if (this.active_destroy_signal != null) {
-        this.active_window_actor.disconnect(this.active_destroy_signal);
-        delete this.active_destroy_signal;
-      }
-    }
+    this.clear_active_window();
 
     if (window_actor.is_destroyed() || this.is_ignored(window_actor)) {
       delete this.active_window_actor;
@@ -234,8 +245,58 @@ export class GnomeFocusManager {
     }
   };
 
+  refresh = (): void => {
+    const focused_window = global.display.focus_window;
+    let focused_actor: Meta.WindowActor | undefined;
+
+    for (const window_actor of global.get_window_actors()) {
+      if (window_actor.is_destroyed()) {
+        continue;
+      }
+
+      const window = window_actor.get_meta_window();
+      if (!window || !is_valid_window_type(window) || this.is_ignored(window_actor)) {
+        continue;
+      }
+
+      if (focused_window === window) {
+        focused_actor = window_actor;
+        continue;
+      }
+
+      this.update_inactive_window_actor(window_actor);
+    }
+
+    if (focused_actor) {
+      this.set_active_window_actor(focused_actor);
+    } else {
+      this.clear_active_window();
+    }
+  };
+
+  suspend_effects = (): void => {
+    this.clear_active_window(false);
+
+    for (const window_actor of global.get_window_actors()) {
+      if (window_actor.is_destroyed()) {
+        continue;
+      }
+
+      const window = window_actor.get_meta_window();
+      if (!window || !is_valid_window_type(window) || this.is_ignored(window_actor)) {
+        continue;
+      }
+
+      GnomeFocusManager.set_opacity(window_actor, 100);
+      this.set_blur(window_actor, false);
+      this.set_desaturate(window_actor, false, this.settings.desaturate_percentage);
+    }
+  };
+
   disable(): void {
     this.settings.clear();
+    this.clear_active_window(false);
+
     for (const window_actor of global.get_window_actors()) {
       GnomeFocusManager.set_opacity(window_actor, 100);
       window_actor.remove_effect_by_name(BLUR_EFFECT_NAME);

--- a/src/GnomeFocusManager.ts
+++ b/src/GnomeFocusManager.ts
@@ -276,6 +276,25 @@ export class GnomeFocusManager {
     }
   };
 
+  suspend_effects = (): void => {
+    this.clear_active_window(false);
+
+    for (const window_actor of global.get_window_actors()) {
+      if (window_actor.is_destroyed() || this.is_ignored(window_actor)) {
+        continue;
+      }
+
+      const window = window_actor.get_meta_window();
+      if (!window || !is_valid_window_type(window)) {
+        continue;
+      }
+
+      GnomeFocusManager.set_opacity(window_actor, 100);
+      this.set_blur(window_actor, false);
+      this.set_desaturate(window_actor, false, this.settings.desaturate_percentage);
+    }
+  };
+
   disable(): void {
     this.settings.clear();
     this.clear_active_window(false);

--- a/src/GnomeFocusManager.ts
+++ b/src/GnomeFocusManager.ts
@@ -247,6 +247,10 @@ export class GnomeFocusManager {
 
   refresh = (): void => {
     const focused_window = global.display.focus_window;
+    if (!focused_window || !is_valid_window_type(focused_window)) {
+      return;
+    }
+
     let focused_actor: Meta.WindowActor | undefined;
 
     for (const window_actor of global.get_window_actors()) {
@@ -269,27 +273,6 @@ export class GnomeFocusManager {
 
     if (focused_actor) {
       this.set_active_window_actor(focused_actor);
-    } else {
-      this.clear_active_window();
-    }
-  };
-
-  suspend_effects = (): void => {
-    this.clear_active_window(false);
-
-    for (const window_actor of global.get_window_actors()) {
-      if (window_actor.is_destroyed()) {
-        continue;
-      }
-
-      const window = window_actor.get_meta_window();
-      if (!window || !is_valid_window_type(window) || this.is_ignored(window_actor)) {
-        continue;
-      }
-
-      GnomeFocusManager.set_opacity(window_actor, 100);
-      this.set_blur(window_actor, false);
-      this.set_desaturate(window_actor, false, this.settings.desaturate_percentage);
     }
   };
 

--- a/src/GnomeFocusManager.ts
+++ b/src/GnomeFocusManager.ts
@@ -14,6 +14,12 @@ const DESATURATE_EFFECT_NAME = 'gnome-focus-desaturate';
 
 /** Window Types that should be considered for focus changes */
 const WINDOW_TYPES = [Meta.WindowType.NORMAL];
+
+function is_desktop_icons_window(window: Meta.Window): boolean {
+  const title = window.get_title();
+  return title?.startsWith('Desktop Icons ') ?? false;
+}
+
 export function is_valid_window_type(window: Meta.Window): boolean {
   return WINDOW_TYPES.includes(window.get_window_type());
 }
@@ -32,6 +38,11 @@ export class GnomeFocusManager {
     settings.on('is-background-blur', this.update_is_background_blur);
     settings.on('is-desaturate-enabled', this.update_is_desaturate_enabled);
     settings.on('desaturate-percentage', this.update_desaturate_percentage);
+  }
+
+  static get_opacity_targets(window_actor: Meta.WindowActor): Clutter.Actor[] {
+    const targets = window_actor.get_children();
+    return targets.length > 0 ? targets : [window_actor];
   }
 
   is_special = (window_actor: Meta.WindowActor): boolean => {
@@ -57,11 +68,15 @@ export class GnomeFocusManager {
       return true;
     }
 
+    const window = window_actor.get_meta_window();
+    if (window && is_desktop_icons_window(window)) {
+      return true;
+    }
+
     if (!this.ignore_inactive) {
       return false;
     }
 
-    const window = window_actor.get_meta_window();
     return (
       !!window &&
       (!is_valid_window_type(window) ||
@@ -80,11 +95,9 @@ export class GnomeFocusManager {
     }
 
     const true_opacity = (DEFAULT_OPACITY * percentage) / 100;
-    for (const actor of window_actor.get_children()) {
+    for (const actor of GnomeFocusManager.get_opacity_targets(window_actor)) {
       actor.set_opacity(true_opacity);
     }
-
-    window_actor.set_opacity(true_opacity);
   }
 
   set_blur(window_actor: Meta.WindowActor, blur: boolean): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,5 @@
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import { load_config } from './config.js';
@@ -6,8 +8,36 @@ import { GnomeFocusManager, is_valid_window_type } from './GnomeFocusManager.js'
 import { get_settings } from './settings.js';
 
 let focus_signal: number | undefined;
+let background_signal: number | undefined;
+let background_dark_signal: number | undefined;
+let refresh_timeout: number | undefined;
 
 let extension_instance: GnomeFocusManager | undefined;
+let background_settings: Gio.Settings | undefined;
+
+function clear_refresh_timeout() {
+  if (refresh_timeout === undefined) {
+    return;
+  }
+
+  GLib.source_remove(refresh_timeout);
+  refresh_timeout = undefined;
+}
+
+function schedule_refresh(delay: number) {
+  clear_refresh_timeout();
+
+  refresh_timeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
+    refresh_timeout = undefined;
+    extension_instance?.refresh();
+    return GLib.SOURCE_REMOVE;
+  });
+}
+
+function background_changed() {
+  extension_instance?.suspend_effects();
+  schedule_refresh(600);
+}
 
 function focus_changed() {
   const window = global.display.focus_window;
@@ -27,6 +57,9 @@ export default class GnomeFocus extends Extension {
     );
 
     focus_signal = global.display.connect('notify::focus-window', focus_changed);
+    background_settings = new Gio.Settings({ schema_id: 'org.gnome.desktop.background' });
+    background_signal = background_settings.connect('changed::picture-uri', background_changed);
+    background_dark_signal = background_settings.connect('changed::picture-uri-dark', background_changed);
 
     for (const actor of global.get_window_actors()) {
       if (actor.is_destroyed()) {
@@ -53,6 +86,20 @@ export default class GnomeFocus extends Extension {
       global.display.disconnect(focus_signal);
       focus_signal = undefined;
     }
+
+    clear_refresh_timeout();
+
+    if (background_settings && background_signal !== undefined) {
+      background_settings.disconnect(background_signal);
+      background_signal = undefined;
+    }
+
+    if (background_settings && background_dark_signal !== undefined) {
+      background_settings.disconnect(background_dark_signal);
+      background_dark_signal = undefined;
+    }
+
+    background_settings = undefined;
 
     if (undefined !== extension_instance) {
       extension_instance.disable();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,17 +7,20 @@ import { GnomeFocusManager, is_valid_window_type } from './GnomeFocusManager.js'
 import { get_settings } from './settings.js';
 import { Timeouts } from './timeout.js';
 
-type ExtendedWindow = Meta.Window & {
-  _focus_extension_signal?: number;
-};
-
 let create_signal: number | undefined;
+
+let focus_signal: number | undefined;
 
 let extension_instance: GnomeFocusManager | undefined;
 
 let timeout_manager: Timeouts | undefined;
 
 function get_window_actor(window: Meta.Window) {
+  const actor = window.get_compositor_private() as Meta.WindowActor | null;
+  if (actor && !actor.is_destroyed()) {
+    return actor;
+  }
+
   for (const actor of global.get_window_actors()) {
     if (!actor.is_destroyed() && actor.get_meta_window() === window) {
       return actor;
@@ -27,7 +30,12 @@ function get_window_actor(window: Meta.Window) {
   return undefined;
 }
 
-function focus_changed(window: Meta.Window) {
+function focus_changed() {
+  const window = global.display.focus_window;
+  if (!window) {
+    return;
+  }
+
   const actor = get_window_actor(window);
   if (actor) {
     extension_instance?.set_active_window_actor(actor);
@@ -42,16 +50,16 @@ export default class GnomeFocus extends Extension {
       load_config<string[]>(this.metadata, 'ignore_focus.json')
     );
 
-    create_signal = global.display.connect('window-created', function (_, win: ExtendedWindow) {
+    focus_signal = global.display.connect('notify::focus-window', focus_changed);
+
+    create_signal = global.display.connect('window-created', function (_, win: Meta.Window) {
       if (!is_valid_window_type(win)) {
         return;
       }
 
-      win._focus_extension_signal = win.connect('focus', focus_changed);
-
       timeout_manager ??= new Timeouts();
 
-      // In Wayland, when we have a new window, we need ot have a slight delay before
+      // In Wayland, when we have a new window, we need a slight delay before
       // attempting to set the transparency.
       timeout_manager.add(() => {
         if (!win) {
@@ -70,7 +78,7 @@ export default class GnomeFocus extends Extension {
             return false;
           }
 
-          if (win.has_focus()) {
+          if (global.display.focus_window === win) {
             extension_instance.set_active_window_actor(actor);
           } else {
             extension_instance.update_inactive_window_actor(actor);
@@ -88,21 +96,23 @@ export default class GnomeFocus extends Extension {
         continue;
       }
 
-      const win = actor.get_meta_window() as ExtendedWindow;
+      const win = actor.get_meta_window();
+      if (!win) {
+        continue;
+      }
+
       if (!is_valid_window_type(win)) {
         continue;
       }
 
-      if (undefined === win._focus_extension_signal) {
-        win._focus_extension_signal = win.connect('focus', focus_changed);
-      }
-
-      if (win.has_focus()) {
+      if (global.display.focus_window === win) {
         extension_instance.set_active_window_actor(actor);
       } else {
         extension_instance.update_inactive_window_actor(actor);
       }
     }
+
+    focus_changed();
   }
 
   disable() {
@@ -111,20 +121,13 @@ export default class GnomeFocus extends Extension {
       create_signal = undefined;
     }
 
+    if (undefined !== focus_signal) {
+      global.display.disconnect(focus_signal);
+      focus_signal = undefined;
+    }
+
     timeout_manager?.clear();
     timeout_manager = undefined;
-
-    for (const actor of global.get_window_actors()) {
-      if (actor.is_destroyed()) {
-        continue;
-      }
-
-      const win: ExtendedWindow | null = actor.get_meta_window();
-      if (win?._focus_extension_signal) {
-        win.disconnect(win._focus_extension_signal);
-        delete win._focus_extension_signal;
-      }
-    }
 
     if (undefined !== extension_instance) {
       extension_instance.disable();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,15 +5,10 @@ import { load_config } from './config.js';
 import { GnomeFocusManager, is_valid_window_type } from './GnomeFocusManager.js';
 
 import { get_settings } from './settings.js';
-import { Timeouts } from './timeout.js';
-
-let create_signal: number | undefined;
 
 let focus_signal: number | undefined;
 
 let extension_instance: GnomeFocusManager | undefined;
-
-let timeout_manager: Timeouts | undefined;
 
 function get_window_actor(window: Meta.Window) {
   const actor = window.get_compositor_private() as Meta.WindowActor | null;
@@ -52,45 +47,6 @@ export default class GnomeFocus extends Extension {
 
     focus_signal = global.display.connect('notify::focus-window', focus_changed);
 
-    create_signal = global.display.connect('window-created', function (_, win: Meta.Window) {
-      if (!is_valid_window_type(win)) {
-        return;
-      }
-
-      timeout_manager ??= new Timeouts();
-
-      // In Wayland, when we have a new window, we need a slight delay before
-      // attempting to set the transparency.
-      timeout_manager.add(() => {
-        if (!win) {
-          return false;
-        }
-
-        if (undefined === extension_instance) {
-          return false;
-        }
-
-        // We could have something go wrong, but always want to set false,
-        // otherwise we end up being called more than once
-        try {
-          const actor = get_window_actor(win);
-          if (undefined === actor || actor.is_destroyed()) {
-            return false;
-          }
-
-          if (global.display.focus_window === win) {
-            extension_instance.set_active_window_actor(actor);
-          } else {
-            extension_instance.update_inactive_window_actor(actor);
-          }
-        } catch (err) {
-          console.error(`Error on new window: ${err}`);
-        }
-
-        return false;
-      }, 350);
-    });
-
     for (const actor of global.get_window_actors()) {
       if (actor.is_destroyed()) {
         continue;
@@ -116,18 +72,10 @@ export default class GnomeFocus extends Extension {
   }
 
   disable() {
-    if (undefined !== create_signal) {
-      global.display.disconnect(create_signal);
-      create_signal = undefined;
-    }
-
     if (undefined !== focus_signal) {
       global.display.disconnect(focus_signal);
       focus_signal = undefined;
     }
-
-    timeout_manager?.clear();
-    timeout_manager = undefined;
 
     if (undefined !== extension_instance) {
       extension_instance.disable();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+import GLib from 'gi://GLib';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
@@ -9,14 +10,39 @@ import { get_settings } from './settings.js';
 let focus_signal: number | undefined;
 let overview_shown_signal: number | undefined;
 let overview_hidden_signal: number | undefined;
+let refresh_timeout: number | undefined;
 
 let extension_instance: GnomeFocusManager | undefined;
+
+function clear_refresh_timeout() {
+  if (refresh_timeout === undefined) {
+    return;
+  }
+
+  GLib.source_remove(refresh_timeout);
+  refresh_timeout = undefined;
+}
+
+function schedule_refresh(delay = 0) {
+  clear_refresh_timeout();
+
+  refresh_timeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
+    refresh_timeout = undefined;
+
+    if (!Main.overview.visible) {
+      extension_instance?.refresh();
+    }
+
+    return GLib.SOURCE_REMOVE;
+  });
+}
 
 function focus_changed() {
   if (Main.overview.visible) {
     return;
   }
 
+  clear_refresh_timeout();
   extension_instance?.refresh();
 }
 
@@ -30,10 +56,11 @@ export default class GnomeFocus extends Extension {
 
     focus_signal = global.display.connect('notify::focus-window', focus_changed);
     overview_shown_signal = Main.overview.connect('shown', () => {
+      clear_refresh_timeout();
       extension_instance?.suspend_effects();
     });
     overview_hidden_signal = Main.overview.connect('hidden', () => {
-      extension_instance?.refresh();
+      schedule_refresh(150);
     });
 
     for (const actor of global.get_window_actors()) {
@@ -71,6 +98,8 @@ export default class GnomeFocus extends Extension {
       Main.overview.disconnect(overview_hidden_signal);
       overview_hidden_signal = undefined;
     }
+
+    clear_refresh_timeout();
 
     if (undefined !== extension_instance) {
       extension_instance.disable();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
-import Meta from 'gi://Meta';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { load_config } from './config.js';
 import { GnomeFocusManager, is_valid_window_type } from './GnomeFocusManager.js';
@@ -7,34 +7,17 @@ import { GnomeFocusManager, is_valid_window_type } from './GnomeFocusManager.js'
 import { get_settings } from './settings.js';
 
 let focus_signal: number | undefined;
+let overview_shown_signal: number | undefined;
+let overview_hidden_signal: number | undefined;
 
 let extension_instance: GnomeFocusManager | undefined;
 
-function get_window_actor(window: Meta.Window) {
-  const actor = window.get_compositor_private() as Meta.WindowActor | null;
-  if (actor && !actor.is_destroyed()) {
-    return actor;
-  }
-
-  for (const actor of global.get_window_actors()) {
-    if (!actor.is_destroyed() && actor.get_meta_window() === window) {
-      return actor;
-    }
-  }
-
-  return undefined;
-}
-
 function focus_changed() {
-  const window = global.display.focus_window;
-  if (!window) {
+  if (Main.overview.visible) {
     return;
   }
 
-  const actor = get_window_actor(window);
-  if (actor) {
-    extension_instance?.set_active_window_actor(actor);
-  }
+  extension_instance?.refresh();
 }
 
 export default class GnomeFocus extends Extension {
@@ -46,6 +29,12 @@ export default class GnomeFocus extends Extension {
     );
 
     focus_signal = global.display.connect('notify::focus-window', focus_changed);
+    overview_shown_signal = Main.overview.connect('shown', () => {
+      extension_instance?.suspend_effects();
+    });
+    overview_hidden_signal = Main.overview.connect('hidden', () => {
+      extension_instance?.refresh();
+    });
 
     for (const actor of global.get_window_actors()) {
       if (actor.is_destroyed()) {
@@ -61,20 +50,26 @@ export default class GnomeFocus extends Extension {
         continue;
       }
 
-      if (global.display.focus_window === win) {
-        extension_instance.set_active_window_actor(actor);
-      } else {
-        extension_instance.update_inactive_window_actor(actor);
-      }
+      extension_instance.update_inactive_window_actor(actor);
     }
 
-    focus_changed();
+    extension_instance.refresh();
   }
 
   disable() {
     if (undefined !== focus_signal) {
       global.display.disconnect(focus_signal);
       focus_signal = undefined;
+    }
+
+    if (undefined !== overview_shown_signal) {
+      Main.overview.disconnect(overview_shown_signal);
+      overview_shown_signal = undefined;
+    }
+
+    if (undefined !== overview_hidden_signal) {
+      Main.overview.disconnect(overview_hidden_signal);
+      overview_hidden_signal = undefined;
     }
 
     if (undefined !== extension_instance) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,4 @@
-import GLib from 'gi://GLib';
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
-import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { load_config } from './config.js';
 import { GnomeFocusManager, is_valid_window_type } from './GnomeFocusManager.js';
@@ -8,41 +6,15 @@ import { GnomeFocusManager, is_valid_window_type } from './GnomeFocusManager.js'
 import { get_settings } from './settings.js';
 
 let focus_signal: number | undefined;
-let overview_shown_signal: number | undefined;
-let overview_hidden_signal: number | undefined;
-let refresh_timeout: number | undefined;
 
 let extension_instance: GnomeFocusManager | undefined;
 
-function clear_refresh_timeout() {
-  if (refresh_timeout === undefined) {
-    return;
-  }
-
-  GLib.source_remove(refresh_timeout);
-  refresh_timeout = undefined;
-}
-
-function schedule_refresh(delay = 0) {
-  clear_refresh_timeout();
-
-  refresh_timeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
-    refresh_timeout = undefined;
-
-    if (!Main.overview.visible) {
-      extension_instance?.refresh();
-    }
-
-    return GLib.SOURCE_REMOVE;
-  });
-}
-
 function focus_changed() {
-  if (Main.overview.visible) {
+  const window = global.display.focus_window;
+  if (!window || !is_valid_window_type(window)) {
     return;
   }
 
-  clear_refresh_timeout();
   extension_instance?.refresh();
 }
 
@@ -55,13 +27,6 @@ export default class GnomeFocus extends Extension {
     );
 
     focus_signal = global.display.connect('notify::focus-window', focus_changed);
-    overview_shown_signal = Main.overview.connect('shown', () => {
-      clear_refresh_timeout();
-      extension_instance?.suspend_effects();
-    });
-    overview_hidden_signal = Main.overview.connect('hidden', () => {
-      schedule_refresh(150);
-    });
 
     for (const actor of global.get_window_actors()) {
       if (actor.is_destroyed()) {
@@ -88,18 +53,6 @@ export default class GnomeFocus extends Extension {
       global.display.disconnect(focus_signal);
       focus_signal = undefined;
     }
-
-    if (undefined !== overview_shown_signal) {
-      Main.overview.disconnect(overview_shown_signal);
-      overview_shown_signal = undefined;
-    }
-
-    if (undefined !== overview_hidden_signal) {
-      Main.overview.disconnect(overview_hidden_signal);
-      overview_hidden_signal = undefined;
-    }
-
-    clear_refresh_timeout();
 
     if (undefined !== extension_instance) {
       extension_instance.disable();


### PR DESCRIPTION
## Summary
- add GNOME 50 to the advertised shell compatibility list
- track focused windows through `notify::focus-window` and prefer `get_compositor_private()` when resolving window actors
- apply opacity to the active window actor targets used by GNOME 50 and ignore DING desktop windows to avoid dimming the desktop

## Testing
- built the extension locally with `corepack yarn build:package`
- verified the extension loads and works on Ubuntu 26.04 LTS with GNOME Shell 50.1 after restarting the GNOME session