### PR TITLE
Add special focus window preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ A quick GNOME extension for apply transparency to inactive windows.
 
 ## Settings
 
-Open Focus from the GNOME Extensions app to configure opacity, inactive-window effects, and exclusions.
+Open Focus from the GNOME Extensions app to configure opacity, inactive-window effects, special focus windows,
+and exclusions.
+
+### Special Focus Windows
+
+Use the **Special Focus Windows** preferences page to add or remove windows that should use the special focused
+opacity while active.
 
 ### Excluded Windows
 
@@ -16,31 +22,26 @@ Use the **Excluded Windows** preferences page to add or remove exact criteria. A
 - its `WM_CLASS` instance
 - its full window title
 
-Matching is case-sensitive. On X11, `xprop WM_CLASS` can show the class and instance; GNOME Shell's Looking Glass can help inspect windows on Wayland. Blank entries are not stored, duplicate entries are removed, and changes apply immediately while the extension is enabled.
+Both lists use exact, case-sensitive matches against a window's `WM_CLASS`, `WM_CLASS` instance, or full title. On
+X11, `xprop WM_CLASS` can show the class and instance; GNOME Shell's Looking Glass can help inspect windows on
+Wayland. Blank entries are not stored, duplicate entries are removed, and changes apply immediately while the
+extension is enabled.
 
-Optional JSON configuration files are read from `~/.config/focus@scaryrawr.github.io/`. When that directory is
-not present, Focus falls back to its legacy `~/.config/Focus/` location. Each file must contain a JSON array of
-strings; invalid files are ignored with a warning in the GNOME Shell log.
+## Legacy JSON Lists
 
-### Special Focus List
+Existing JSON lists remain supported and are merged with the corresponding preferences. Focus reads them from
+`~/.config/focus@scaryrawr.github.io/`, falling back to the legacy `~/.config/Focus/` directory when the preferred
+directory is absent. Each file must contain a JSON array of strings; invalid files are ignored with a warning in
+the GNOME Shell log.
 
-A special focus list can be created at `~/.config/focus@scaryrawr.github.io/special_focus.json`.
-
-Windows that match the list criteria will have an opacity applied to them that can be adjusted in the Extension Preference Window.
-
-It uses the WM_CLASS (use `xprop` to help figure them out).
+`special_focus.json` adds special focus windows:
 
 ```json
 ["Code", "Code - Insiders"]
 ```
 
-## Legacy Ignore List
-
-An ignore list can be created at `~/.config/focus@scaryrawr.github.io/ignore_focus.json`.
-
-Windows that match the list criteria will not have their appearance modified even when inactive.
-
-The legacy list is still honored and merged with exclusions from preferences. Focus reads it without modifying or overwriting the file. Criteria use the same exact, case-sensitive `WM_CLASS`, instance, or full-title matching described above. The example below lets Firefox's Picture-in-Picture keep its normal appearance.
+`ignore_focus.json` adds excluded windows. This example lets Firefox's Picture-in-Picture keep its normal
+appearance:
 
 ```json
 ["Toolkit"]

--- a/schemas/org.gnome.shell.extensions.focus.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.focus.gschema.xml
@@ -11,6 +11,11 @@
 			<range min="0" max="100"/>
 			<summary>Opacity of focused window if in special focus list 0-100</summary>
 		</key>
+		<key name="special-focus-windows" type="as">
+			<default>[]</default>
+			<summary>Windows that retain transparency while focused</summary>
+			<description>Exact case-sensitive matches for WM_CLASS, WM_CLASS instance, or window title.</description>
+		</key>
 		<key name="focus-opacity" type="u">
 			<default>100</default>
 			<range min="0" max="100"/>

--- a/src/GnomeFocusManager.ts
+++ b/src/GnomeFocusManager.ts
@@ -47,17 +47,31 @@ export function is_valid_window_type(window: Meta.Window): boolean {
   return WINDOW_TYPES.includes(window.get_window_type());
 }
 
+/** Checks exact window identity fields against one optional criterion list. */
+function window_matches(window: Meta.Window, criteria: readonly string[] | undefined): boolean {
+  return (
+    criteria?.some(
+      criterion =>
+        criterion === window.get_wm_class() ||
+        criterion === window.get_wm_class_instance() ||
+        criterion === window.get_title()
+    ) ?? false
+  );
+}
+
 export class GnomeFocusManager {
   active_window_actor: Meta.WindowActor | undefined;
+  private special_focus_windows: string[];
   private excluded_windows: string[];
   private readonly owned_window_states = new Map<Meta.WindowActor, OwnedWindowState>();
 
   constructor(
     readonly settings: FocusSettings,
-    readonly special_focus: string[] | undefined,
+    readonly legacy_special_focus: string[] | undefined,
     readonly legacy_ignore_inactive: string[] | undefined,
     readonly pending_window_actors: ReadonlySet<Meta.WindowActor>
   ) {
+    this.special_focus_windows = settings.special_focus_windows;
     this.excluded_windows = settings.excluded_windows;
     settings.on('focus-opacity', this.update_focused_window_opacity);
     settings.on('special-opacity', this.update_special_focused_window_opacity);
@@ -65,6 +79,7 @@ export class GnomeFocusManager {
     settings.on('is-background-blur', this.update_is_background_blur);
     settings.on('is-desaturate-enabled', this.update_is_desaturate_enabled);
     settings.on('desaturate-percentage', this.update_desaturate_percentage);
+    settings.on('special-focus-windows', this.update_special_focus_windows);
     settings.on('excluded-windows', this.update_excluded_windows);
   }
 
@@ -141,7 +156,7 @@ export class GnomeFocusManager {
   };
 
   is_special = (window_actor: Meta.WindowActor): boolean => {
-    if (!this.special_focus || window_actor.is_destroyed()) {
+    if (window_actor.is_destroyed()) {
       return false;
     }
 
@@ -149,12 +164,7 @@ export class GnomeFocusManager {
     return (
       !!window &&
       is_valid_window_type(window) &&
-      this.special_focus.some(
-        criteria =>
-          criteria === window.get_wm_class() ||
-          criteria === window.get_wm_class_instance() ||
-          criteria === window.get_title()
-      )
+      (window_matches(window, this.legacy_special_focus) || window_matches(window, this.special_focus_windows))
     );
   };
 
@@ -176,18 +186,8 @@ export class GnomeFocusManager {
     return (
       !!window &&
       (!is_valid_window_type(window) ||
-        this.legacy_ignore_inactive?.some(
-          criteria =>
-            criteria === window.get_wm_class() ||
-            criteria === window.get_wm_class_instance() ||
-            criteria === window.get_title()
-        ) ||
-        this.excluded_windows.some(
-          criteria =>
-            criteria === window.get_wm_class() ||
-            criteria === window.get_wm_class_instance() ||
-            criteria === window.get_title()
-        ))
+        window_matches(window, this.legacy_ignore_inactive) ||
+        window_matches(window, this.excluded_windows))
     );
   };
 
@@ -383,6 +383,18 @@ export class GnomeFocusManager {
 
       this.set_desaturate(window_actor, enabled, percentage);
     }
+  };
+
+  update_special_focus_windows = (criteria: string[]): void => {
+    this.special_focus_windows = criteria;
+    if (!this.active_window_actor) {
+      return;
+    }
+
+    const opacity = this.is_special(this.active_window_actor)
+      ? this.settings.special_focus_opacity
+      : this.settings.focus_opacity;
+    this.set_opacity(this.active_window_actor, opacity);
   };
 
   update_excluded_windows = (criteria: string[]): void => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,7 @@ export default class GnomeFocus extends Extension {
     this.config_cancellable = undefined;
 
     const settings = get_settings(this.getSettings());
+    settings.normalize_special_focus_windows();
     settings.normalize_excluded_windows();
     const pending_window_actors = new Set<Meta.WindowActor>();
     this.pending_window_actors = pending_window_actors;

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -3,7 +3,7 @@ import Gtk from 'gi://Gtk';
 
 import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-import { FocusSettings, get_settings, normalize_excluded_window_criterion } from './settings.js';
+import { FocusSettings, get_settings, normalize_window_criterion } from './settings.js';
 
 type PercentageRowOptions = {
   title: string;
@@ -62,7 +62,7 @@ function add_appearance_page(window: Adw.PreferencesWindow, settings: FocusSetti
   opacity_group.add(
     create_percentage_row({
       title: 'Special focus windows',
-      subtitle: 'Focused opacity for matches from special_focus.json',
+      subtitle: 'Focused opacity for windows listed under Special Focus Windows',
       value: settings.special_focus_opacity,
       step: 5,
       set_value: value => settings.set_special_focus_opacity(value)
@@ -106,16 +106,27 @@ function add_appearance_page(window: Adw.PreferencesWindow, settings: FocusSetti
   window.add(page);
 }
 
-/** Adds one removable exact-match criterion row. */
-function add_exclusion_row(
+type WindowListPageOptions = {
+  title: string;
+  icon_name: string;
+  description: string;
+  entry_title: string;
+  row_subtitle: string;
+  get_criteria: () => string[];
+  set_criteria: (criteria: readonly string[]) => void;
+  normalize_criteria: () => string[];
+};
+
+/** Adds one removable exact-match window criterion row. */
+function add_window_criterion_row(
   group: Adw.PreferencesGroup,
-  settings: FocusSettings,
   criterion: string,
+  options: WindowListPageOptions,
   on_removed: () => void
 ): void {
   const row = new Adw.ActionRow({
     title: criterion,
-    subtitle: 'Matches WM_CLASS, WM_CLASS instance, or window title',
+    subtitle: options.row_subtitle,
     subtitle_selectable: true,
     use_markup: false
   });
@@ -126,7 +137,7 @@ function add_exclusion_row(
   });
   remove_button.add_css_class('flat');
   remove_button.connect('clicked', () => {
-    settings.set_excluded_windows(settings.excluded_windows.filter(value => value !== criterion));
+    options.set_criteria(options.get_criteria().filter(value => value !== criterion));
     group.remove(row);
     on_removed();
   });
@@ -135,19 +146,18 @@ function add_exclusion_row(
   group.add(row);
 }
 
-/** Adds the editor for GSettings-backed exclusion criteria. */
-function add_exclusions_page(window: Adw.PreferencesWindow, settings: FocusSettings): void {
+/** Adds a preferences page for one GSettings-backed exact-match window list. */
+function add_window_list_page(window: Adw.PreferencesWindow, options: WindowListPageOptions): void {
   const page = new Adw.PreferencesPage({
-    title: 'Excluded Windows',
-    icon_name: 'action-unavailable-symbolic'
+    title: options.title,
+    icon_name: options.icon_name
   });
   const group = new Adw.PreferencesGroup({
     title: 'Exact Matches',
-    description:
-      'Excluded windows keep their normal appearance. Matching is exact and case-sensitive against WM_CLASS, its instance, or the full window title.'
+    description: options.description
   });
   const entry_row = new Adw.EntryRow({
-    title: 'Add WM_CLASS, instance, or title'
+    title: options.entry_title
   });
   const add_button = new Gtk.Button({
     icon_name: 'list-add-symbolic',
@@ -159,19 +169,19 @@ function add_exclusions_page(window: Adw.PreferencesWindow, settings: FocusSetti
   group.add(entry_row);
 
   const update_add_button = (): void => {
-    const criterion = normalize_excluded_window_criterion(entry_row.get_text());
-    const is_duplicate = criterion ? settings.excluded_windows.includes(criterion) : false;
+    const criterion = normalize_window_criterion(entry_row.get_text());
+    const is_duplicate = criterion ? options.get_criteria().includes(criterion) : false;
     add_button.set_sensitive(!!criterion && !is_duplicate);
     add_button.set_tooltip_text(is_duplicate ? 'Criterion already exists' : 'Add criterion');
   };
   const add_criterion = (): void => {
-    const criterion = normalize_excluded_window_criterion(entry_row.get_text());
-    if (!criterion || settings.excluded_windows.includes(criterion)) {
+    const criterion = normalize_window_criterion(entry_row.get_text());
+    if (!criterion || options.get_criteria().includes(criterion)) {
       return;
     }
 
-    settings.set_excluded_windows([...settings.excluded_windows, criterion]);
-    add_exclusion_row(group, settings, criterion, update_add_button);
+    options.set_criteria([...options.get_criteria(), criterion]);
+    add_window_criterion_row(group, criterion, options, update_add_button);
     entry_row.set_text('');
   };
 
@@ -180,12 +190,42 @@ function add_exclusions_page(window: Adw.PreferencesWindow, settings: FocusSetti
   add_button.connect('clicked', add_criterion);
   update_add_button();
 
-  for (const criterion of settings.normalize_excluded_windows()) {
-    add_exclusion_row(group, settings, criterion, update_add_button);
+  for (const criterion of options.normalize_criteria()) {
+    add_window_criterion_row(group, criterion, options, update_add_button);
   }
 
   page.add(group);
   window.add(page);
+}
+
+/** Adds the editor for windows that remain transparent while focused. */
+function add_special_focus_page(window: Adw.PreferencesWindow, settings: FocusSettings): void {
+  add_window_list_page(window, {
+    title: 'Special Focus Windows',
+    icon_name: 'starred-symbolic',
+    description:
+      'Special focus windows use the special focused opacity while active. Matching is exact and case-sensitive against WM_CLASS, its instance, or the full window title.',
+    entry_title: 'Add WM_CLASS, instance, or title',
+    row_subtitle: 'Uses special focused opacity when active',
+    get_criteria: () => settings.special_focus_windows,
+    set_criteria: criteria => settings.set_special_focus_windows(criteria),
+    normalize_criteria: () => settings.normalize_special_focus_windows()
+  });
+}
+
+/** Adds the editor for windows excluded from all focus effects. */
+function add_exclusions_page(window: Adw.PreferencesWindow, settings: FocusSettings): void {
+  add_window_list_page(window, {
+    title: 'Excluded Windows',
+    icon_name: 'action-unavailable-symbolic',
+    description:
+      'Excluded windows keep their normal appearance. Matching is exact and case-sensitive against WM_CLASS, its instance, or the full window title.',
+    entry_title: 'Add WM_CLASS, instance, or title',
+    row_subtitle: 'Matches WM_CLASS, WM_CLASS instance, or window title',
+    get_criteria: () => settings.excluded_windows,
+    set_criteria: criteria => settings.set_excluded_windows(criteria),
+    normalize_criteria: () => settings.normalize_excluded_windows()
+  });
 }
 
 export default class GnomeFocusPreferences extends ExtensionPreferences {
@@ -193,6 +233,7 @@ export default class GnomeFocusPreferences extends ExtensionPreferences {
     const settings = get_settings(this.getSettings());
     window.set_search_enabled(true);
     add_appearance_page(window, settings);
+    add_special_focus_page(window, settings);
     add_exclusions_page(window, settings);
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,7 @@ type SettingsChangeEvents = {
   'is-background-blur': boolean;
   'is-desaturate-enabled': boolean;
   'desaturate-percentage': number;
+  'special-focus-windows': string[];
   'excluded-windows': string[];
 };
 
@@ -22,19 +23,19 @@ type ListenerMap<Type> = {
 
 type SettingsListenerMap = ListenerMap<SettingsChangeEvents>;
 
-/** Returns one trimmed, non-empty exact-match criterion. */
-export function normalize_excluded_window_criterion(criterion: string): string | undefined {
+/** Returns one trimmed, non-empty exact-match window criterion. */
+export function normalize_window_criterion(criterion: string): string | undefined {
   const normalized = criterion.trim();
   return normalized.length > 0 ? normalized : undefined;
 }
 
-/** Canonicalizes exact-match criteria while preserving their original order. */
-export function normalize_excluded_window_criteria(criteria: readonly string[]): string[] {
+/** Canonicalizes exact-match window criteria while preserving their original order. */
+export function normalize_window_criteria(criteria: readonly string[]): string[] {
   const normalized_criteria: string[] = [];
   const seen_criteria = new Set<string>();
 
   for (const criterion of criteria) {
-    const normalized = normalize_excluded_window_criterion(criterion);
+    const normalized = normalize_window_criterion(criterion);
     if (normalized && !seen_criteria.has(normalized)) {
       seen_criteria.add(normalized);
       normalized_criteria.push(normalized);
@@ -54,6 +55,7 @@ export class FocusSettings {
     'is-background-blur': [],
     'desaturate-percentage': [],
     'is-desaturate-enabled': [],
+    'special-focus-windows': [],
     'excluded-windows': []
   };
 
@@ -109,24 +111,40 @@ export class FocusSettings {
     this.settings.set_boolean('is-desaturate-enabled', val);
   }
 
+  get special_focus_windows(): string[] {
+    return normalize_window_criteria(this.settings.get_strv('special-focus-windows'));
+  }
+
+  set_special_focus_windows(criteria: readonly string[]): void {
+    this.settings.set_strv('special-focus-windows', normalize_window_criteria(criteria));
+  }
+
   get excluded_windows(): string[] {
-    return normalize_excluded_window_criteria(this.settings.get_strv('excluded-windows'));
+    return normalize_window_criteria(this.settings.get_strv('excluded-windows'));
   }
 
   set_excluded_windows(criteria: readonly string[]): void {
-    this.settings.set_strv('excluded-windows', normalize_excluded_window_criteria(criteria));
+    this.settings.set_strv('excluded-windows', normalize_window_criteria(criteria));
   }
 
-  /** Rewrites manually edited settings into the format used by the preferences UI. */
-  normalize_excluded_windows(): string[] {
-    const stored_criteria = this.settings.get_strv('excluded-windows');
-    const normalized_criteria = normalize_excluded_window_criteria(stored_criteria);
+  /** Rewrites manually edited special-focus settings into the preferences format. */
+  normalize_special_focus_windows(): string[] {
+    return this.normalize_window_list('special-focus-windows');
+  }
 
+  /** Rewrites manually edited exclusion settings into the preferences format. */
+  normalize_excluded_windows(): string[] {
+    return this.normalize_window_list('excluded-windows');
+  }
+
+  private normalize_window_list(key: 'special-focus-windows' | 'excluded-windows'): string[] {
+    const stored_criteria = this.settings.get_strv(key);
+    const normalized_criteria = normalize_window_criteria(stored_criteria);
     if (
       stored_criteria.length !== normalized_criteria.length ||
       stored_criteria.some((criterion, index) => criterion !== normalized_criteria[index])
     ) {
-      this.settings.set_strv('excluded-windows', normalized_criteria);
+      this.settings.set_strv(key, normalized_criteria);
     }
 
     return normalized_criteria;
@@ -149,6 +167,9 @@ export class FocusSettings {
             case 'is-background-blur':
             case 'is-desaturate-enabled':
               this.emit(key, this.settings.get_boolean(key));
+              break;
+            case 'special-focus-windows':
+              this.emit(key, this.special_focus_windows);
               break;
             case 'excluded-windows':
               this.emit(key, this.excluded_windows);


### PR DESCRIPTION
Special focus windows could previously only be configured through `special_focus.json`, while excluded windows already had a dedicated preferences editor. This adds the same discoverable settings experience for windows that should retain transparency while focused.

- Add a **Special Focus Windows** preferences page with normalized, exact-match add/remove controls.
- Store criteria in GSettings and apply updates immediately to the active window.
- Continue merging legacy `special_focus.json` entries for backward compatibility.
- Share matching and list-editor behavior with excluded windows and update the user documentation.